### PR TITLE
feat: Add `@ValidateWith` and `.validateWith` to configs

### DIFF
--- a/common-example/src/main/java/com/example/balm/ExampleConfig.java
+++ b/common-example/src/main/java/com/example/balm/ExampleConfig.java
@@ -1,10 +1,13 @@
 package com.example.balm;
 
+import com.mojang.serialization.DataResult;
+import net.blay09.mods.balm.platform.config.schema.ConfigValidator;
 import net.blay09.mods.balm.platform.config.reflection.CustomControl;
 import net.blay09.mods.balm.platform.config.reflection.Comment;
 import net.blay09.mods.balm.platform.config.reflection.Config;
 import net.blay09.mods.balm.platform.config.reflection.NestedType;
 import net.blay09.mods.balm.platform.config.reflection.Range;
+import net.blay09.mods.balm.platform.config.reflection.ValidateWith;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.StringRepresentable;
 
@@ -22,6 +25,7 @@ public class ExampleConfig {
     public boolean fancyBoolean;
 
     @Comment("Example string config value.")
+    @ValidateWith(WelcomeMessageValidator.class)
     public String welcomeMessage = "Hello from Balm!";
 
     @Comment("Example identifier config value.")
@@ -83,5 +87,16 @@ public class ExampleConfig {
 
         @Comment("Example child screen number.")
         public int number = 987;
+    }
+
+    public static class WelcomeMessageValidator implements ConfigValidator<String> {
+        @Override
+        public DataResult<String> validate(String value) {
+            if (value.isBlank()) {
+                return DataResult.error(() -> "Welcome message must not be blank");
+            }
+
+            return DataResult.success(value);
+        }
     }
 }

--- a/common-example/src/main/java/com/example/balm/ExampleConfig.java
+++ b/common-example/src/main/java/com/example/balm/ExampleConfig.java
@@ -7,6 +7,7 @@ import net.blay09.mods.balm.platform.config.reflection.Comment;
 import net.blay09.mods.balm.platform.config.reflection.Config;
 import net.blay09.mods.balm.platform.config.reflection.NestedType;
 import net.blay09.mods.balm.platform.config.reflection.Range;
+import net.blay09.mods.balm.platform.config.reflection.ValidateCollectionWith;
 import net.blay09.mods.balm.platform.config.reflection.ValidateWith;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.StringRepresentable;
@@ -36,6 +37,8 @@ public class ExampleConfig {
 
     @Comment("Example list config value.")
     @NestedType(String.class)
+    @ValidateWith(FavoriteItemValidator.class)
+    @ValidateCollectionWith(FavoriteItemsValidator.class)
     public List<String> favoriteItems = List.of("minecraft:apple", "minecraft:bread");
 
     @Comment("Example set config value.")
@@ -94,6 +97,29 @@ public class ExampleConfig {
         public DataResult<String> validate(String value) {
             if (value.isBlank()) {
                 return DataResult.error(() -> "Welcome message must not be blank");
+            }
+
+            return DataResult.success(value);
+        }
+    }
+
+    public static class FavoriteItemValidator implements ConfigValidator<String> {
+        @Override
+        public DataResult<String> validate(String value) {
+            try {
+                final var identifier = Identifier.parse(value);
+                return identifier.getNamespace().equals("minecraft") ? DataResult.success(value) : DataResult.error(() -> "must be of minecraft namespace");
+            } catch (Exception e) {
+                return DataResult.error(() -> "Favorite item must be a valid identifier in the minecraft namespace");
+            }
+        }
+    }
+
+    public static class FavoriteItemsValidator implements ConfigValidator<List<String>> {
+        @Override
+        public DataResult<List<String>> validate(List<String> value) {
+            if (value.size() > 3) {
+                return DataResult.error(() -> "Favorite items must not have more than 3 items");
             }
 
             return DataResult.success(value);

--- a/common/src/main/java/net/blay09/mods/balm/client/platform/config/screen/list/BalmConfigListEditorContext.java
+++ b/common/src/main/java/net/blay09/mods/balm/client/platform/config/screen/list/BalmConfigListEditorContext.java
@@ -24,5 +24,5 @@ public interface BalmConfigListEditorContext<T> {
 
     void delete(BalmConfigListEditorEntry<T> entry);
 
-    void commit();
+    boolean commit();
 }

--- a/common/src/main/java/net/blay09/mods/balm/client/platform/config/screen/list/BalmConfigListEditorEntry.java
+++ b/common/src/main/java/net/blay09/mods/balm/client/platform/config/screen/list/BalmConfigListEditorEntry.java
@@ -4,6 +4,8 @@ import com.mojang.serialization.DataResult;
 import net.blay09.mods.balm.client.platform.config.screen.list.internal.BalmConfigListDragHandleButton;
 import net.blay09.mods.balm.client.platform.config.screen.list.internal.BalmConfigListEditorValue;
 import net.blay09.mods.balm.platform.config.schema.ConfigControlBinding;
+import net.blay09.mods.balm.platform.config.schema.ConfiguredList;
+import net.blay09.mods.balm.platform.config.schema.ConfiguredSet;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.ContainerObjectSelectionList;
@@ -12,7 +14,6 @@ import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 
 public abstract class BalmConfigListEditorEntry<T> extends ContainerObjectSelectionList.Entry<BalmConfigListEditorEntry<T>> {
@@ -110,15 +111,17 @@ public abstract class BalmConfigListEditorEntry<T> extends ContainerObjectSelect
             return DataResult.success(null);
         }
 
-        return binding.property().type() == Set.class
-                ? validateValue(binding, Set.of(value))
-                : validateValue(binding, List.of(value));
+        return validateElement(binding, value);
 
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private DataResult<?> validateValue(ConfigControlBinding<? extends Collection<T>> binding, Collection<T> value) {
-        return ((ConfigControlBinding) binding).validateValue(value);
+    protected DataResult<T> validateElement(ConfigControlBinding<? extends Collection<T>> binding, T value) {
+        return switch (binding.property()) {
+            case ConfiguredList<?> configuredList -> ((ConfiguredList<T>) configuredList).validateElement(value);
+            case ConfiguredSet<?> configuredSet -> ((ConfiguredSet<T>) configuredSet).validateElement(value);
+            default -> ((ConfigControlBinding) binding).validateValue(value);
+        };
     }
 
     private int getActionWidgetsWidth() {

--- a/common/src/main/java/net/blay09/mods/balm/client/platform/config/screen/list/BalmConfigListEditorScreen.java
+++ b/common/src/main/java/net/blay09/mods/balm/client/platform/config/screen/list/BalmConfigListEditorScreen.java
@@ -303,10 +303,8 @@ public class BalmConfigListEditorScreen<T> extends Screen implements BalmConfigL
 
     private void revalidateValues() {
         final var result = validateValues(pendingCommitValues());
-        result.error().ifPresentOrElse(
-                error -> context.setValidationError(binding.property(), Component.literal(error.message())),
-                () -> context.clearValidationError(binding.property())
-        );
+        result.ifSuccess(_ -> context.clearValidationError(binding.property()))
+                .ifError(error -> context.setValidationError(binding.property(), Component.literal(error.message())));
     }
 
     private Collection<T> pendingCommitValues() {

--- a/common/src/main/java/net/blay09/mods/balm/client/platform/config/screen/list/BalmConfigListEditorScreen.java
+++ b/common/src/main/java/net/blay09/mods/balm/client/platform/config/screen/list/BalmConfigListEditorScreen.java
@@ -104,8 +104,9 @@ public class BalmConfigListEditorScreen<T> extends Screen implements BalmConfigL
         validationErrorWidget = footerLayout.addChild(new StringWidget(Component.empty(), font),
                 settings -> settings.align(0.5f, 0f).paddingTop(VALIDATION_ERROR_TOP_PADDING));
         doneButton = footerLayout.addChild(Button.builder(CommonComponents.GUI_DONE, _ -> {
-                    commit();
-                    onClose();
+                    if (commit()) {
+                        onClose();
+                    }
                 }).build(),
                 settings -> settings.align(0.5f, 1f).paddingBottom(FOOTER_BUTTON_BOTTOM_PADDING));
         layout.visitWidgets(this::addRenderableWidget);
@@ -222,15 +223,20 @@ public class BalmConfigListEditorScreen<T> extends Screen implements BalmConfigL
     }
 
     @Override
-    public void commit() {
-        final var rawValues = state.rawValues();
-        final var pendingCommitValues = binding.property() instanceof ConfiguredSet<?>
-                ? new LinkedHashSet<>(rawValues)
-                : List.copyOf(rawValues);
-        if (validateValues(pendingCommitValues).isSuccess()) {
-            setValues(pendingCommitValues);
-            refreshList();
+    public boolean commit() {
+        final var pendingCommitValues = pendingCommitValues();
+        final var result = validateValues(pendingCommitValues);
+        if (!result.isSuccess()) {
+            result.error().ifPresent(error -> context.setValidationError(binding.property(), Component.literal(error.message())));
+            updateWidgets();
+            return false;
         }
+
+        setValues(pendingCommitValues);
+        context.clearValidationError(binding.property());
+        refreshList();
+        updateWidgets();
+        return true;
     }
 
     private void refreshList() {
@@ -288,11 +294,26 @@ public class BalmConfigListEditorScreen<T> extends Screen implements BalmConfigL
                     .findFirst()
                     .ifPresentOrElse(
                             error -> context.setValidationError(binding.property(), Component.literal(error.message())),
-                            () -> context.clearValidationError(binding.property())
+                            this::revalidateValues
                     );
         }
 
         updateWidgets();
+    }
+
+    private void revalidateValues() {
+        final var result = validateValues(pendingCommitValues());
+        result.error().ifPresentOrElse(
+                error -> context.setValidationError(binding.property(), Component.literal(error.message())),
+                () -> context.clearValidationError(binding.property())
+        );
+    }
+
+    private Collection<T> pendingCommitValues() {
+        final var rawValues = state.rawValues();
+        return binding.property() instanceof ConfiguredSet<?>
+                ? new LinkedHashSet<>(rawValues)
+                : List.copyOf(rawValues);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/common/src/main/java/net/blay09/mods/balm/client/platform/config/screen/list/internal/BalmConfigListEditorInlineStringValueEntry.java
+++ b/common/src/main/java/net/blay09/mods/balm/client/platform/config/screen/list/internal/BalmConfigListEditorInlineStringValueEntry.java
@@ -5,7 +5,9 @@ import net.blay09.mods.balm.client.platform.config.screen.list.BalmConfigListEdi
 import net.blay09.mods.balm.client.platform.config.screen.list.BalmConfigListEditorEntry;
 import net.blay09.mods.balm.platform.config.internal.PrimitiveConfigCodecs;
 import net.blay09.mods.balm.platform.config.schema.ConfigControlBinding;
+import net.blay09.mods.balm.platform.config.schema.ConfiguredList;
 import net.blay09.mods.balm.platform.config.schema.ConfiguredProperty;
+import net.blay09.mods.balm.platform.config.schema.ConfiguredSet;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.EditBox;
@@ -93,7 +95,7 @@ public class BalmConfigListEditorInlineStringValueEntry<T> extends BalmConfigLis
     @Override
     public DataResult<?> validate(ConfigControlBinding<? extends Collection<T>> binding) {
         if (valueHolder.entryState() instanceof EditState(String value)) {
-            return parseValue(value);
+            return parseValue(value).flatMap(parsedValue -> validateElement(binding, parsedValue));
         }
 
         return super.validate(binding);
@@ -101,7 +103,7 @@ public class BalmConfigListEditorInlineStringValueEntry<T> extends BalmConfigLis
 
     public void setValue(String value) {
         valueHolder.entryState(new EditState(value));
-        parseValue(value).ifSuccess(validValue -> {
+        validatePendingValue(value).ifSuccess(validValue -> {
             valueHolder.value(validValue);
             context.revalidate();
         }).ifError(error -> context.setValidationError(this, Component.literal(error.message())));
@@ -172,12 +174,21 @@ public class BalmConfigListEditorInlineStringValueEntry<T> extends BalmConfigLis
     }
 
     public boolean canCommit() {
-        return parseValue(getPendingValue()).isSuccess();
+        return validatePendingValue(getPendingValue()).isSuccess();
     }
 
     @SuppressWarnings("unchecked")
     private DataResult<T> parseValue(String value) {
         return PrimitiveConfigCodecs.parse((ConfiguredProperty<T>) context.property(), value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private DataResult<T> validatePendingValue(String value) {
+        return parseValue(value).flatMap(parsedValue -> switch (context.property()) {
+            case ConfiguredList<?> configuredList -> ((ConfiguredList<T>) configuredList).validateElement(parsedValue);
+            case ConfiguredSet<?> configuredSet -> ((ConfiguredSet<T>) configuredSet).validateElement(parsedValue);
+            default -> ((ConfiguredProperty<T>) context.property()).validateValue(parsedValue);
+        });
     }
 
     protected void onDoneButton(Button button) {

--- a/common/src/main/java/net/blay09/mods/balm/platform/compatibility/config/internal/ClothConfigSupport.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/compatibility/config/internal/ClothConfigSupport.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 public class ClothConfigSupport {
     private static final Logger logger = LoggerFactory.getLogger(ClothConfigSupport.class);
+    private static final Component INVALID_IDENTIFIER_ERROR = Component.translatable("gui.balm.configuration.validation.invalid_identifier");
 
     public ClothConfigSupport() {
         BalmConfigScreenProviders.register("cloth-config", ClothConfigSupport::getConfigScreenFactory);
@@ -80,6 +81,7 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startStrField(label, stringProperty.get(config))
                             .setDefaultValue(stringProperty.defaultValue())
                             .setTooltip(tooltip)
+                            .setErrorSupplier(value -> validateOrError(stringProperty, value))
                             .setSaveConsumer(value -> stringProperty.set(config, value))
                             .build()
             );
@@ -87,6 +89,7 @@ public class ClothConfigSupport {
                 var fieldBuilder = builder.entryBuilder().startIntField(label, intProperty.get(config))
                         .setDefaultValue(intProperty.defaultValue())
                         .setTooltip(tooltip)
+                        .setErrorSupplier(value -> validateOrError(intProperty, value))
                         .setSaveConsumer(value -> intProperty.set(config, value));
                 fieldBuilder = intProperty.minValue().map(fieldBuilder::setMin).orElse(fieldBuilder);
                 fieldBuilder = intProperty.maxValue().map(fieldBuilder::setMax).orElse(fieldBuilder);
@@ -96,6 +99,7 @@ public class ClothConfigSupport {
                 var fieldBuilder = builder.entryBuilder().startFloatField(label, floatProperty.get(config))
                         .setDefaultValue(floatProperty.defaultValue())
                         .setTooltip(tooltip)
+                        .setErrorSupplier(value -> validateOrError(floatProperty, value))
                         .setSaveConsumer(value -> floatProperty.set(config, value));
                 fieldBuilder = floatProperty.minValue().map(fieldBuilder::setMin).orElse(fieldBuilder);
                 fieldBuilder = floatProperty.maxValue().map(fieldBuilder::setMax).orElse(fieldBuilder);
@@ -105,6 +109,7 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startBooleanToggle(label, booleanProperty.get(config))
                             .setDefaultValue(booleanProperty.defaultValue())
                             .setTooltip(tooltip)
+                            .setErrorSupplier(value -> validateOrError(booleanProperty, value))
                             .setSaveConsumer(value -> booleanProperty.set(config, value))
                             .build()
             );
@@ -113,6 +118,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startStrList(label, (List<String>) listProperty.get(config))
                             .setDefaultValue((List<String>) listProperty.defaultValue())
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateListElementOrError((ConfiguredList<String>) listProperty, value))
+                            .setErrorSupplier(value -> validateOrError((ConfiguredList<String>) listProperty, value))
                             .setSaveConsumer(value -> ((ConfiguredList<String>) listProperty).set(config, value))
                             .build()
             );
@@ -120,6 +127,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startIntList(label, (List<Integer>) listProperty.get(config))
                             .setDefaultValue((List<Integer>) listProperty.defaultValue())
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateListElementOrError((ConfiguredList<Integer>) listProperty, value))
+                            .setErrorSupplier(value -> validateOrError((ConfiguredList<Integer>) listProperty, value))
                             .setSaveConsumer(value -> ((ConfiguredList<Integer>) listProperty).set(config, value))
                             .build()
             );
@@ -127,6 +136,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startLongList(label, (List<Long>) listProperty.get(config))
                             .setDefaultValue((List<Long>) listProperty.defaultValue())
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateListElementOrError((ConfiguredList<Long>) listProperty, value))
+                            .setErrorSupplier(value -> validateOrError((ConfiguredList<Long>) listProperty, value))
                             .setSaveConsumer(value -> ((ConfiguredList<Long>) listProperty).set(config, value))
                             .build()
             );
@@ -134,6 +145,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startFloatList(label, (List<Float>) listProperty.get(config))
                             .setDefaultValue((List<Float>) listProperty.defaultValue())
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateListElementOrError((ConfiguredList<Float>) listProperty, value))
+                            .setErrorSupplier(value -> validateOrError((ConfiguredList<Float>) listProperty, value))
                             .setSaveConsumer(value -> ((ConfiguredList<Float>) listProperty).set(config, value))
                             .build()
             );
@@ -141,6 +154,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startDoubleList(label, (List<Double>) listProperty.get(config))
                             .setDefaultValue((List<Double>) listProperty.defaultValue())
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateListElementOrError((ConfiguredList<Double>) listProperty, value))
+                            .setErrorSupplier(value -> validateOrError((ConfiguredList<Double>) listProperty, value))
                             .setSaveConsumer(value -> ((ConfiguredList<Double>) listProperty).set(config, value))
                             .build()
             );
@@ -148,6 +163,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startStrList(label, listProperty.get(config).stream().map(Objects::toString).toList())
                             .setDefaultValue(listProperty.defaultValue().stream().map(Objects::toString).toList())
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateIdentifierListElementOrError((ConfiguredList<Identifier>) listProperty, value))
+                            .setErrorSupplier(value -> validateIdentifierListOrError((ConfiguredList<Identifier>) listProperty, value))
                             .setSaveConsumer(value -> ((ConfiguredList<Identifier>) listProperty).set(config, value.stream().map(Identifier::tryParse).filter(Objects::nonNull).collect(Collectors.toList())))
                             .build()
             );
@@ -155,6 +172,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startStrList(label, new ArrayList<>((Set<String>) setProperty.get(config)))
                             .setDefaultValue(new ArrayList<>((Set<String>) setProperty.defaultValue()))
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateSetElementOrError((ConfiguredSet<String>) setProperty, value))
+                            .setErrorSupplier(value -> validateOrError((ConfiguredSet<String>) setProperty, new HashSet<>(value)))
                             .setSaveConsumer(value -> ((ConfiguredSet<String>) setProperty).set(config, new HashSet<>(value)))
                             .build()
             );
@@ -162,6 +181,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startIntList(label, new ArrayList<>((Set<Integer>) setProperty.get(config)))
                             .setDefaultValue(new ArrayList<>((Set<Integer>) setProperty.defaultValue()))
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateSetElementOrError((ConfiguredSet<Integer>) setProperty, value))
+                            .setErrorSupplier(value -> validateOrError((ConfiguredSet<Integer>) setProperty, new HashSet<>(value)))
                             .setSaveConsumer(value -> ((ConfiguredSet<Integer>) setProperty).set(config, new HashSet<>(value)))
                             .build()
             );
@@ -169,6 +190,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startLongList(label, new ArrayList<>((Set<Long>) setProperty.get(config)))
                             .setDefaultValue(new ArrayList<>((Set<Long>) setProperty.defaultValue()))
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateSetElementOrError((ConfiguredSet<Long>) setProperty, value))
+                            .setErrorSupplier(value -> validateOrError((ConfiguredSet<Long>) setProperty, new HashSet<>(value)))
                             .setSaveConsumer(value -> ((ConfiguredSet<Long>) setProperty).set(config, new HashSet<>(value)))
                             .build()
             );
@@ -176,6 +199,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startFloatList(label, new ArrayList<>((Set<Float>) setProperty.get(config)))
                             .setDefaultValue(new ArrayList<>((Set<Float>) setProperty.defaultValue()))
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateSetElementOrError((ConfiguredSet<Float>) setProperty, value))
+                            .setErrorSupplier(value -> validateOrError((ConfiguredSet<Float>) setProperty, new HashSet<>(value)))
                             .setSaveConsumer(value -> ((ConfiguredSet<Float>) setProperty).set(config, new HashSet<>(value)))
                             .build()
             );
@@ -183,6 +208,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startDoubleList(label, new ArrayList<>((Set<Double>) setProperty.get(config)))
                             .setDefaultValue(new ArrayList<>((Set<Double>) setProperty.defaultValue()))
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateSetElementOrError((ConfiguredSet<Double>) setProperty, value))
+                            .setErrorSupplier(value -> validateOrError((ConfiguredSet<Double>) setProperty, new HashSet<>(value)))
                             .setSaveConsumer(value -> ((ConfiguredSet<Double>) setProperty).set(config, new HashSet<>(value)))
                             .build()
             );
@@ -190,6 +217,8 @@ public class ClothConfigSupport {
                     builder.entryBuilder().startStrList(label, setProperty.get(config).stream().map(Objects::toString).toList())
                             .setDefaultValue(setProperty.defaultValue().stream().map(Objects::toString).toList())
                             .setTooltip(tooltip)
+                            .setCellErrorSupplier(value -> validateIdentifierSetElementOrError((ConfiguredSet<Identifier>) setProperty, value))
+                            .setErrorSupplier(value -> validateIdentifierSetOrError((ConfiguredSet<Identifier>) setProperty, value))
                             .setSaveConsumer(value -> ((ConfiguredSet<Identifier>) setProperty).set(config, value.stream().map(Identifier::tryParse).filter(Objects::nonNull).collect(Collectors.toSet())))
                             .build()
             );
@@ -236,8 +265,55 @@ public class ClothConfigSupport {
                         .startEnumSelector(displayName, (Class<T>) property.type(), property.get(config))
                         .setDefaultValue(property.defaultValue())
                         .setTooltip(tooltip)
+                        .setErrorSupplier(value -> validateOrError(property, value))
                         .setSaveConsumer(value -> property.set(config, value))
                         .build()
         );
+    }
+
+    private static <T> Optional<Component> validateOrError(ConfiguredProperty<T> property, T value) {
+        return property.validateValue(value).error().map(error -> Component.literal(error.message()));
+    }
+
+    private static <T> Optional<Component> validateListElementOrError(ConfiguredList<T> property, T value) {
+        return property.validateElement(value).error().map(error -> Component.literal(error.message()));
+    }
+
+    private static <T> Optional<Component> validateSetElementOrError(ConfiguredSet<T> property, T value) {
+        return property.validateElement(value).error().map(error -> Component.literal(error.message()));
+    }
+
+    private static Optional<Component> validateIdentifierListElementOrError(ConfiguredList<Identifier> property, String value) {
+        final var identifier = Identifier.tryParse(value);
+        return identifier != null ? validateListElementOrError(property, identifier) : Optional.of(INVALID_IDENTIFIER_ERROR);
+    }
+
+    private static Optional<Component> validateIdentifierListOrError(ConfiguredList<Identifier> property, List<String> value) {
+        final var identifiers = new ArrayList<Identifier>();
+        for (final var stringValue : value) {
+            final var identifier = Identifier.tryParse(stringValue);
+            if (identifier == null) {
+                return Optional.of(INVALID_IDENTIFIER_ERROR);
+            }
+            identifiers.add(identifier);
+        }
+        return validateOrError(property, identifiers);
+    }
+
+    private static Optional<Component> validateIdentifierSetElementOrError(ConfiguredSet<Identifier> property, String value) {
+        final var identifier = Identifier.tryParse(value);
+        return identifier != null ? validateSetElementOrError(property, identifier) : Optional.of(INVALID_IDENTIFIER_ERROR);
+    }
+
+    private static Optional<Component> validateIdentifierSetOrError(ConfiguredSet<Identifier> property, List<String> value) {
+        final var identifiers = new HashSet<Identifier>();
+        for (final var stringValue : value) {
+            final var identifier = Identifier.tryParse(stringValue);
+            if (identifier == null) {
+                return Optional.of(INVALID_IDENTIFIER_ERROR);
+            }
+            identifiers.add(identifier);
+        }
+        return validateOrError(property, identifiers);
     }
 }

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/reflection/ValidateCollectionWith.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/reflection/ValidateCollectionWith.java
@@ -1,0 +1,14 @@
+package net.blay09.mods.balm.platform.config.reflection;
+
+import net.blay09.mods.balm.platform.config.schema.ConfigValidator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidateCollectionWith {
+    Class<? extends ConfigValidator<?>> value();
+}

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/reflection/ValidateWith.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/reflection/ValidateWith.java
@@ -1,0 +1,14 @@
+package net.blay09.mods.balm.platform.config.reflection;
+
+import net.blay09.mods.balm.platform.config.schema.ConfigValidator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidateWith {
+    Class<? extends ConfigValidator<?>> value();
+}

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/reflection/internal/ConfigReflection.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/reflection/internal/ConfigReflection.java
@@ -54,6 +54,10 @@ public class ConfigReflection {
             if (controlAnnotation != null) {
                 property.customControl(parseDefaultedIdentifier(controlAnnotation.value(), getIdentifier(clazz).getNamespace()));
             }
+            final var validateWithAnnotation = field.getAnnotation(ValidateWith.class);
+            if (validateWithAnnotation != null) {
+                property.validateWith(validateWithAnnotation.value());
+            }
             final var rangeAnnotation = field.getAnnotation(Range.class);
             final var type = field.getType();
             final var nestedTypeAnnotation = field.getAnnotation(NestedType.class);

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/reflection/internal/ConfigReflection.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/reflection/internal/ConfigReflection.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -58,8 +59,15 @@ public class ConfigReflection {
             if (validateWithAnnotation != null) {
                 property.validateWith(validateWithAnnotation.value());
             }
+            final var validateCollectionWithAnnotation = field.getAnnotation(ValidateCollectionWith.class);
+            if (validateCollectionWithAnnotation != null) {
+                property.validateCollectionWith(validateCollectionWithAnnotation.value());
+            }
             final var rangeAnnotation = field.getAnnotation(Range.class);
             final var type = field.getType();
+            if (validateCollectionWithAnnotation != null && !Collection.class.isAssignableFrom(type)) {
+                throw new IllegalArgumentException("@ValidateCollectionWith can only be used on collection fields: " + field.getName() + " in class " + clazz.getName());
+            }
             final var nestedTypeAnnotation = field.getAnnotation(NestedType.class);
             final var nestedType = nestedTypeAnnotation != null ? nestedTypeAnnotation.value() : null;
             try {

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/ConfigValidator.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/ConfigValidator.java
@@ -1,0 +1,7 @@
+package net.blay09.mods.balm.platform.config.schema;
+
+import com.mojang.serialization.DataResult;
+
+public interface ConfigValidator<T> {
+    DataResult<T> validate(T value);
+}

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/ConfiguredList.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/ConfiguredList.java
@@ -1,5 +1,6 @@
 package net.blay09.mods.balm.platform.config.schema;
 
+import com.mojang.serialization.DataResult;
 import net.blay09.mods.balm.Balm;
 import net.blay09.mods.balm.platform.config.LoadedConfig;
 import net.blay09.mods.balm.platform.config.MutableLoadedConfig;
@@ -7,6 +8,10 @@ import net.blay09.mods.balm.platform.config.MutableLoadedConfig;
 import java.util.List;
 
 public interface ConfiguredList<T> extends ConfiguredProperty<List<T>>, NestedTypeHolder<T> {
+    boolean hasCustomCollectionValidator();
+
+    DataResult<T> validateElement(T value);
+
     default List<T> get(LoadedConfig config) {
         return getRaw(config);
     }

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/ConfiguredProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/ConfiguredProperty.java
@@ -23,6 +23,8 @@ public interface ConfiguredProperty<T> {
 
     Optional<Identifier> customControl();
 
+    boolean hasCustomValidator();
+
     Class<?> type();
 
     Codec<T> codec();

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/ConfiguredSet.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/ConfiguredSet.java
@@ -1,5 +1,6 @@
 package net.blay09.mods.balm.platform.config.schema;
 
+import com.mojang.serialization.DataResult;
 import net.blay09.mods.balm.Balm;
 import net.blay09.mods.balm.platform.config.LoadedConfig;
 import net.blay09.mods.balm.platform.config.MutableLoadedConfig;
@@ -7,6 +8,10 @@ import net.blay09.mods.balm.platform.config.MutableLoadedConfig;
 import java.util.Set;
 
 public interface ConfiguredSet<T> extends ConfiguredProperty<Set<T>>, NestedTypeHolder<T> {
+    boolean hasCustomCollectionValidator();
+
+    DataResult<T> validateElement(T value);
+
     default Set<T> get(LoadedConfig config) {
         return getRaw(config);
     }

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/AbstractConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/AbstractConfigProperty.java
@@ -1,5 +1,7 @@
 package net.blay09.mods.balm.platform.config.schema.builder;
 
+import com.mojang.serialization.DataResult;
+import net.blay09.mods.balm.platform.config.schema.ConfigValidator;
 import net.blay09.mods.balm.platform.config.schema.ConfiguredProperty;
 import net.blay09.mods.balm.platform.config.schema.internal.ConfigSchemaImpl;
 import net.minecraft.resources.Identifier;
@@ -14,6 +16,7 @@ public abstract class AbstractConfigProperty<T> implements ConfiguredProperty<T>
     private final String comment;
     private final boolean synced;
     private final @Nullable Identifier customControl;
+    private final @Nullable ConfigValidator<T> validator;
 
     public AbstractConfigProperty(ConfigPropertyBuilder parent) {
         schema = parent.schema;
@@ -22,6 +25,20 @@ public abstract class AbstractConfigProperty<T> implements ConfiguredProperty<T>
         comment = parent.comment;
         synced = parent.synced;
         customControl = parent.customControl;
+        validator = createValidator(parent.validatorClass);
+    }
+
+    @SuppressWarnings("unchecked")
+    private @Nullable ConfigValidator<T> createValidator(@Nullable Class<? extends ConfigValidator<?>> validatorClass) {
+        if (validatorClass == null) {
+            return null;
+        }
+
+        try {
+            return (ConfigValidator<T>) validatorClass.getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException("Config validator " + validatorClass.getName() + " must have a public no-arg constructor", e);
+        }
     }
 
     @Override
@@ -52,5 +69,10 @@ public abstract class AbstractConfigProperty<T> implements ConfiguredProperty<T>
     @Override
     public Optional<Identifier> customControl() {
         return Optional.ofNullable(customControl);
+    }
+
+    @Override
+    public DataResult<T> validateValue(T value) {
+        return validator != null ? validator.validate(value) : DataResult.success(value);
     }
 }

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/AbstractConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/AbstractConfigProperty.java
@@ -16,7 +16,7 @@ public abstract class AbstractConfigProperty<T> implements ConfiguredProperty<T>
     private final String comment;
     private final boolean synced;
     private final @Nullable Identifier customControl;
-    private final @Nullable ConfigValidator<T> validator;
+    protected final @Nullable ConfigValidator<?> validator;
 
     public AbstractConfigProperty(ConfigPropertyBuilder parent) {
         schema = parent.schema;
@@ -29,7 +29,7 @@ public abstract class AbstractConfigProperty<T> implements ConfiguredProperty<T>
     }
 
     @SuppressWarnings("unchecked")
-    private @Nullable ConfigValidator<T> createValidator(@Nullable Class<? extends ConfigValidator<?>> validatorClass) {
+    protected static <T> @Nullable ConfigValidator<T> createValidator(@Nullable Class<? extends ConfigValidator<?>> validatorClass) {
         if (validatorClass == null) {
             return null;
         }
@@ -72,7 +72,13 @@ public abstract class AbstractConfigProperty<T> implements ConfiguredProperty<T>
     }
 
     @Override
+    public boolean hasCustomValidator() {
+        return validator != null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
     public DataResult<T> validateValue(T value) {
-        return validator != null ? validator.validate(value) : DataResult.success(value);
+        return validator != null ? ((ConfigValidator<T>) validator).validate(value) : DataResult.success(value);
     }
 }

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/BooleanConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/BooleanConfigProperty.java
@@ -22,6 +22,7 @@ public class BooleanConfigProperty extends AbstractConfigProperty<Boolean> imple
     public BooleanConfigProperty(ConfigPropertyBuilder parent, boolean defaultValue) {
         super(parent);
         this.defaultValue = defaultValue;
+        validateValue(defaultValue).getOrThrow();
     }
 
     @Override
@@ -31,7 +32,7 @@ public class BooleanConfigProperty extends AbstractConfigProperty<Boolean> imple
 
     @Override
     public Codec<Boolean> codec() {
-        return CODEC;
+        return CODEC.validate(this::validateValue);
     }
 
     @Override

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/ConfigPropertyBuilder.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/ConfigPropertyBuilder.java
@@ -17,6 +17,7 @@ public class ConfigPropertyBuilder {
     protected boolean synced;
     protected @Nullable Identifier customControl;
     protected @Nullable Class<? extends ConfigValidator<?>> validatorClass;
+    protected @Nullable Class<? extends ConfigValidator<?>> collectionValidatorClass;
 
     public ConfigPropertyBuilder(ConfigSchemaImpl schema, String name) {
         this.schema = schema;
@@ -47,6 +48,11 @@ public class ConfigPropertyBuilder {
 
     public ConfigPropertyBuilder validateWith(Class<? extends ConfigValidator<?>> validatorClass) {
         this.validatorClass = validatorClass;
+        return this;
+    }
+
+    public ConfigPropertyBuilder validateCollectionWith(Class<? extends ConfigValidator<?>> validatorClass) {
+        this.collectionValidatorClass = validatorClass;
         return this;
     }
 

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/ConfigPropertyBuilder.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/ConfigPropertyBuilder.java
@@ -1,6 +1,7 @@
 package net.blay09.mods.balm.platform.config.schema.builder;
 
 import net.blay09.mods.balm.platform.config.schema.internal.ConfigSchemaImpl;
+import net.blay09.mods.balm.platform.config.schema.ConfigValidator;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.StringRepresentable;
 import org.jspecify.annotations.Nullable;
@@ -15,6 +16,7 @@ public class ConfigPropertyBuilder {
     protected String comment = "";
     protected boolean synced;
     protected @Nullable Identifier customControl;
+    protected @Nullable Class<? extends ConfigValidator<?>> validatorClass;
 
     public ConfigPropertyBuilder(ConfigSchemaImpl schema, String name) {
         this.schema = schema;
@@ -40,6 +42,11 @@ public class ConfigPropertyBuilder {
 
     public ConfigPropertyBuilder customControl(Identifier customControlId) {
         this.customControl = customControlId;
+        return this;
+    }
+
+    public ConfigPropertyBuilder validateWith(Class<? extends ConfigValidator<?>> validatorClass) {
+        this.validatorClass = validatorClass;
         return this;
     }
 

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/DoubleConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/DoubleConfigProperty.java
@@ -35,6 +35,7 @@ public class DoubleConfigProperty extends AbstractConfigProperty<Double> impleme
         this.defaultValue = defaultValue;
         this.minValue = minValue;
         this.maxValue = maxValue;
+        validateValue(defaultValue).getOrThrow();
     }
 
     @Override
@@ -75,6 +76,6 @@ public class DoubleConfigProperty extends AbstractConfigProperty<Double> impleme
         if (maxValue != null && value > maxValue) {
             return DataResult.error(() -> "Value for " + name() + " is above maximum " + maxValue + ": " + value);
         }
-        return DataResult.success(value);
+        return super.validateValue(value);
     }
 }

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/EnumConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/EnumConfigProperty.java
@@ -26,6 +26,7 @@ public class EnumConfigProperty<T extends Enum<T> & StringRepresentable> extends
         final var byIdMapper = ByIdMap.continuous(Enum::ordinal, enumConstants, ByIdMap.OutOfBoundsStrategy.ZERO);
         this.codec = LenientEnumCodecs.fromValues(() -> enumConstants);
         this.streamCodec = ByteBufCodecs.idMapper(byIdMapper, Enum::ordinal).cast();
+        validateValue(defaultValue).getOrThrow();
     }
 
     @Override
@@ -35,7 +36,7 @@ public class EnumConfigProperty<T extends Enum<T> & StringRepresentable> extends
 
     @Override
     public Codec<T> codec() {
-        return codec;
+        return codec.validate(this::validateValue);
     }
 
     @Override

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/FloatConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/FloatConfigProperty.java
@@ -35,6 +35,7 @@ public class FloatConfigProperty extends AbstractConfigProperty<Float> implement
         this.defaultValue = defaultValue;
         this.minValue = minValue;
         this.maxValue = maxValue;
+        validateValue(defaultValue).getOrThrow();
     }
 
     @Override
@@ -75,6 +76,6 @@ public class FloatConfigProperty extends AbstractConfigProperty<Float> implement
         if (maxValue != null && value > maxValue) {
             return DataResult.error(() -> "Value for " + name() + " is above maximum " + maxValue + ": " + value);
         }
-        return DataResult.success(value);
+        return super.validateValue(value);
     }
 }

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/IdentifierConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/IdentifierConfigProperty.java
@@ -12,6 +12,7 @@ public class IdentifierConfigProperty extends AbstractConfigProperty<Identifier>
     public IdentifierConfigProperty(ConfigPropertyBuilder parent, Identifier defaultValue) {
         super(parent);
         this.defaultValue = defaultValue;
+        validateValue(defaultValue).getOrThrow();
     }
 
     @Override
@@ -21,7 +22,7 @@ public class IdentifierConfigProperty extends AbstractConfigProperty<Identifier>
 
     @Override
     public Codec<Identifier> codec() {
-        return Identifier.CODEC;
+        return Identifier.CODEC.validate(this::validateValue);
     }
 
     @Override

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/IntConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/IntConfigProperty.java
@@ -35,6 +35,7 @@ public class IntConfigProperty extends AbstractConfigProperty<Integer> implement
         this.defaultValue = defaultValue;
         this.minValue = minValue;
         this.maxValue = maxValue;
+        validateValue(defaultValue).getOrThrow();
     }
 
     @Override
@@ -75,6 +76,6 @@ public class IntConfigProperty extends AbstractConfigProperty<Integer> implement
         if (maxValue != null && value > maxValue) {
             return DataResult.error(() -> "Value for " + name() + " is above maximum " + maxValue + ": " + value);
         }
-        return DataResult.success(value);
+        return super.validateValue(value);
     }
 }

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/ListConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/ListConfigProperty.java
@@ -1,11 +1,14 @@
 package net.blay09.mods.balm.platform.config.schema.builder;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import io.netty.buffer.ByteBuf;
 import net.blay09.mods.balm.platform.config.internal.PrimitiveConfigCodecs;
+import net.blay09.mods.balm.platform.config.schema.ConfigValidator;
 import net.blay09.mods.balm.platform.config.schema.ConfiguredList;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +18,7 @@ public class ListConfigProperty<T> extends AbstractConfigProperty<List<T>> imple
     private final List<T> defaultValue;
     private final Codec<List<T>> codec;
     private final StreamCodec<ByteBuf, List<T>> streamCodec;
+    private final @Nullable ConfigValidator<List<T>> listValidator;
 
     public ListConfigProperty(ConfigPropertyBuilder parent, Class<T> nestedType, List<T> defaultValue) {
         super(parent);
@@ -22,6 +26,7 @@ public class ListConfigProperty<T> extends AbstractConfigProperty<List<T>> imple
         this.defaultValue = defaultValue;
         this.codec = PrimitiveConfigCodecs.codec(nestedType).listOf();
         this.streamCodec = ByteBufCodecs.collection(ArrayList::new, PrimitiveConfigCodecs.streamCodec(nestedType));
+        this.listValidator = createValidator(parent.collectionValidatorClass);
         validateValue(defaultValue).getOrThrow();
     }
 
@@ -43,6 +48,28 @@ public class ListConfigProperty<T> extends AbstractConfigProperty<List<T>> imple
     @Override
     public Class<T> nestedType() {
         return nestedType;
+    }
+
+    @Override
+    public boolean hasCustomCollectionValidator() {
+        return listValidator != null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public DataResult<T> validateElement(T value) {
+        return validator != null ? ((ConfigValidator<T>) validator).validate(value) : DataResult.success(value);
+    }
+
+    @Override
+    public DataResult<List<T>> validateValue(List<T> value) {
+        for (final var element : value) {
+            final var result = validateElement(element);
+            if (!result.isSuccess()) {
+                return result.map(_ -> value);
+            }
+        }
+        return listValidator != null ? listValidator.validate(value) : DataResult.success(value);
     }
 
     @Override

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/ListConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/ListConfigProperty.java
@@ -22,6 +22,7 @@ public class ListConfigProperty<T> extends AbstractConfigProperty<List<T>> imple
         this.defaultValue = defaultValue;
         this.codec = PrimitiveConfigCodecs.codec(nestedType).listOf();
         this.streamCodec = ByteBufCodecs.collection(ArrayList::new, PrimitiveConfigCodecs.streamCodec(nestedType));
+        validateValue(defaultValue).getOrThrow();
     }
 
     @Override
@@ -31,7 +32,7 @@ public class ListConfigProperty<T> extends AbstractConfigProperty<List<T>> imple
 
     @Override
     public Codec<List<T>> codec() {
-        return codec;
+        return codec.validate(this::validateValue);
     }
 
     @Override

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/LongConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/LongConfigProperty.java
@@ -35,6 +35,7 @@ public class LongConfigProperty extends AbstractConfigProperty<Long> implements 
         this.defaultValue = defaultValue;
         this.minValue = minValue;
         this.maxValue = maxValue;
+        validateValue(defaultValue).getOrThrow();
     }
 
     @Override
@@ -75,6 +76,6 @@ public class LongConfigProperty extends AbstractConfigProperty<Long> implements 
         if (maxValue != null && value > maxValue) {
             return DataResult.error(() -> "Value for " + name() + " is above maximum " + maxValue + ": " + value);
         }
-        return DataResult.success(value);
+        return super.validateValue(value);
     }
 }

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/SetConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/SetConfigProperty.java
@@ -23,6 +23,7 @@ public class SetConfigProperty<T> extends AbstractConfigProperty<Set<T>> impleme
         this.defaultValue = defaultValue;
         this.codec = PrimitiveConfigCodecs.codec(nestedType).listOf();
         this.streamCodec = ByteBufCodecs.collection(ArrayList::new, PrimitiveConfigCodecs.streamCodec(nestedType));
+        validateValue(defaultValue).getOrThrow();
     }
 
     @Override
@@ -32,7 +33,7 @@ public class SetConfigProperty<T> extends AbstractConfigProperty<Set<T>> impleme
 
     @Override
     public Codec<Set<T>> codec() {
-        return codec.xmap(Set::copyOf, List::copyOf);
+        return codec.xmap(Set::copyOf, List::copyOf).validate(this::validateValue);
     }
 
     @Override

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/SetConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/SetConfigProperty.java
@@ -1,11 +1,14 @@
 package net.blay09.mods.balm.platform.config.schema.builder;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import io.netty.buffer.ByteBuf;
 import net.blay09.mods.balm.platform.config.internal.PrimitiveConfigCodecs;
+import net.blay09.mods.balm.platform.config.schema.ConfigValidator;
 import net.blay09.mods.balm.platform.config.schema.ConfiguredSet;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +19,7 @@ public class SetConfigProperty<T> extends AbstractConfigProperty<Set<T>> impleme
     private final Set<T> defaultValue;
     private final Codec<List<T>> codec;
     private final StreamCodec<ByteBuf, List<T>> streamCodec;
+    private final @Nullable ConfigValidator<Set<T>> setValidator;
 
     public SetConfigProperty(ConfigPropertyBuilder parent, Class<T> nestedType, Set<T> defaultValue) {
         super(parent);
@@ -23,6 +27,7 @@ public class SetConfigProperty<T> extends AbstractConfigProperty<Set<T>> impleme
         this.defaultValue = defaultValue;
         this.codec = PrimitiveConfigCodecs.codec(nestedType).listOf();
         this.streamCodec = ByteBufCodecs.collection(ArrayList::new, PrimitiveConfigCodecs.streamCodec(nestedType));
+        this.setValidator = createValidator(parent.collectionValidatorClass);
         validateValue(defaultValue).getOrThrow();
     }
 
@@ -44,6 +49,28 @@ public class SetConfigProperty<T> extends AbstractConfigProperty<Set<T>> impleme
     @Override
     public Class<T> nestedType() {
         return nestedType;
+    }
+
+    @Override
+    public boolean hasCustomCollectionValidator() {
+        return setValidator != null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public DataResult<T> validateElement(T value) {
+        return validator != null ? ((ConfigValidator<T>) validator).validate(value) : DataResult.success(value);
+    }
+
+    @Override
+    public DataResult<Set<T>> validateValue(Set<T> value) {
+        for (final var element : value) {
+            final var result = validateElement(element);
+            if (!result.isSuccess()) {
+                return result.map(_ -> value);
+            }
+        }
+        return setValidator != null ? setValidator.validate(value) : DataResult.success(value);
     }
 
     @Override

--- a/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/StringConfigProperty.java
+++ b/common/src/main/java/net/blay09/mods/balm/platform/config/schema/builder/StringConfigProperty.java
@@ -12,6 +12,7 @@ public class StringConfigProperty extends AbstractConfigProperty<String> impleme
     public StringConfigProperty(ConfigPropertyBuilder parent, String defaultValue) {
         super(parent);
         this.defaultValue = defaultValue;
+        validateValue(defaultValue).getOrThrow();
     }
 
     @Override
@@ -21,7 +22,7 @@ public class StringConfigProperty extends AbstractConfigProperty<String> impleme
 
     @Override
     public Codec<String> codec() {
-        return Codec.STRING;
+        return Codec.STRING.validate(this::validateValue);
     }
 
     @Override

--- a/common/src/main/resources/assets/balm/lang/en_us.json
+++ b/common/src/main/resources/assets/balm/lang/en_us.json
@@ -61,5 +61,6 @@
   "gui.balm.configuration.discard_changes.confirm": "Discard Changes",
   "gui.balm.configuration.validation.range": "Range: %s to %s",
   "gui.balm.configuration.validation.negative_infinity": "-inf",
-  "gui.balm.configuration.validation.positive_infinity": "+inf"
+  "gui.balm.configuration.validation.positive_infinity": "+inf",
+  "gui.balm.configuration.validation.invalid_identifier": "Non [a-z0-9_.-] character in namespace or path of identifier"
 }

--- a/forge/src/main/java/net/blay09/mods/balm/forge/platform/config/internal/ForgeBalmConfig.java
+++ b/forge/src/main/java/net/blay09/mods/balm/forge/platform/config/internal/ForgeBalmConfig.java
@@ -38,31 +38,50 @@ public class ForgeBalmConfig extends AbstractBalmConfig {
         spec.translation(ConfigLocalization.forProperty(property));
 
         return switch (property) {
-            case ConfiguredBoolean configuredBoolean -> spec.define(configuredBoolean.name(), configuredBoolean.defaultValue().booleanValue());
-            case ConfiguredDouble configuredDouble -> configuredDouble.minValue().isPresent() || configuredDouble.maxValue().isPresent()
-                    ? spec.defineInRange(configuredDouble.name(), configuredDouble.defaultValue(), configuredDouble.minValue().orElse(Double.NEGATIVE_INFINITY), configuredDouble.maxValue().orElse(Double.POSITIVE_INFINITY))
-                    : spec.define(configuredDouble.name(), configuredDouble.defaultValue());
+            case ConfiguredBoolean configuredBoolean -> configuredBoolean.hasCustomValidator()
+                    ? spec.define(configuredBoolean.name(), configuredBoolean.defaultValue(), it -> validatePropertyValue(configuredBoolean, it))
+                    : spec.define(configuredBoolean.name(), configuredBoolean.defaultValue().booleanValue());
+            case ConfiguredDouble configuredDouble -> configuredDouble.hasCustomValidator()
+                    ? spec.define(configuredDouble.name(), configuredDouble.defaultValue(), it -> validatePropertyValue(configuredDouble, it))
+                    : spec.defineInRange(configuredDouble.name(), configuredDouble.defaultValue(), configuredDouble.minValue().orElse(Double.NEGATIVE_INFINITY), configuredDouble.maxValue().orElse(Double.POSITIVE_INFINITY));
             case ConfiguredEnum<?> configuredEnum -> defineEnum(spec, configuredEnum);
-            case ConfiguredFloat configuredFloat -> configuredFloat.minValue().isPresent() || configuredFloat.maxValue().isPresent()
-                    ? spec.defineInRange(configuredFloat.name(), configuredFloat.defaultValue().doubleValue(), (double) configuredFloat.minValue().orElse(Float.NEGATIVE_INFINITY), (double) configuredFloat.maxValue().orElse(Float.POSITIVE_INFINITY))
-                    : spec.define(configuredFloat.name(), configuredFloat.defaultValue().doubleValue());
-            case ConfiguredInt configuredInt -> configuredInt.minValue().isPresent() || configuredInt.maxValue().isPresent()
-                    ? spec.defineInRange(configuredInt.name(), configuredInt.defaultValue(), configuredInt.minValue().orElse(Integer.MIN_VALUE), configuredInt.maxValue().orElse(Integer.MAX_VALUE))
-                    : spec.define(configuredInt.name(), configuredInt.defaultValue());
-            case ConfiguredList<?> configuredList -> spec.defineListAllowEmpty(configuredList.name(),
+            case ConfiguredFloat configuredFloat -> configuredFloat.hasCustomValidator()
+                    ? spec.define(configuredFloat.name(), configuredFloat.defaultValue().doubleValue(), it -> validatePropertyValue(configuredFloat, it))
+                    : spec.defineInRange(configuredFloat.name(), configuredFloat.defaultValue().doubleValue(), (double) configuredFloat.minValue().orElse(Float.NEGATIVE_INFINITY), (double) configuredFloat.maxValue().orElse(Float.POSITIVE_INFINITY));
+            case ConfiguredInt configuredInt -> configuredInt.hasCustomValidator()
+                    ? spec.define(configuredInt.name(), configuredInt.defaultValue(), it -> validatePropertyValue(configuredInt, it))
+                    : spec.defineInRange(configuredInt.name(), configuredInt.defaultValue(), configuredInt.minValue().orElse(Integer.MIN_VALUE), configuredInt.maxValue().orElse(Integer.MAX_VALUE));
+            case ConfiguredList<?> configuredList -> configuredList.hasCustomCollectionValidator()
+                    ? spec.define(configuredList.name(),
                     mapConfigCollectionToNeoForge(configuredList.defaultValue()),
-                    (it) -> validateListElement(configuredList, it));
-            case ConfiguredLong configuredLong -> configuredLong.minValue().isPresent() || configuredLong.maxValue().isPresent()
-                    ? spec.defineInRange(configuredLong.name(), configuredLong.defaultValue(), configuredLong.minValue().orElse(Long.MIN_VALUE), configuredLong.maxValue().orElse(Long.MAX_VALUE))
-                    : spec.define(configuredLong.name(), configuredLong.defaultValue());
-            case ConfiguredIdentifier configuredIdentifier ->
-                    spec.define(configuredIdentifier.name(), configuredIdentifier.defaultValue().toString());
-            case ConfiguredSet<?> configuredSet -> spec.defineListAllowEmpty(configuredSet.name(),
+                    it -> validatePropertyValue(configuredList, it))
+                    : spec.defineListAllowEmpty(configuredList.name(),
+                    mapConfigCollectionToNeoForge(configuredList.defaultValue()),
+                    it -> validateListElement(configuredList, it));
+            case ConfiguredLong configuredLong -> configuredLong.hasCustomValidator()
+                    ? spec.define(configuredLong.name(), configuredLong.defaultValue(), it -> validatePropertyValue(configuredLong, it))
+                    : spec.defineInRange(configuredLong.name(), configuredLong.defaultValue(), configuredLong.minValue().orElse(Long.MIN_VALUE), configuredLong.maxValue().orElse(Long.MAX_VALUE));
+            case ConfiguredIdentifier configuredIdentifier -> configuredIdentifier.hasCustomValidator()
+                    ? spec.define(configuredIdentifier.name(), configuredIdentifier.defaultValue().toString(), it -> validatePropertyValue(configuredIdentifier, it))
+                    : spec.define(configuredIdentifier.name(), configuredIdentifier.defaultValue().toString());
+            case ConfiguredSet<?> configuredSet -> configuredSet.hasCustomCollectionValidator()
+                    ? spec.define(configuredSet.name(),
                     mapConfigCollectionToNeoForge(configuredSet.defaultValue()),
-                    (it) -> validateSetElement(configuredSet, it));
-            case ConfiguredString configuredString -> spec.define(configuredString.name(), configuredString.defaultValue());
+                    it -> validatePropertyValue(configuredSet, it))
+                    : spec.defineListAllowEmpty(configuredSet.name(),
+                    mapConfigCollectionToNeoForge(configuredSet.defaultValue()),
+                    it -> validateSetElement(configuredSet, it));
+            case ConfiguredString configuredString -> configuredString.hasCustomValidator()
+                    ? spec.define(configuredString.name(), configuredString.defaultValue(), it -> validatePropertyValue(configuredString, it))
+                    : spec.define(configuredString.name(), configuredString.defaultValue());
             default -> throw new IllegalStateException("Unexpected value: " + property);
         };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> boolean validatePropertyValue(ConfiguredProperty<T> property, Object value) {
+        final var mappedValue = (T) mapConfigValueFromNeoForge(property, value);
+        return property.validateValue(mappedValue).isSuccess();
     }
 
     public static List<?> mapConfigCollectionToNeoForge(Collection<?> values) {
@@ -110,14 +129,26 @@ public class ForgeBalmConfig extends AbstractBalmConfig {
     }
 
     private static <T> boolean validateListElement(ConfiguredList<T> configuredList, Object value) {
-        return validateCollectionElement(configuredList.nestedType(), value);
+        return validateCollectionElementType(configuredList.nestedType(), value) && validateCollectionElement(configuredList, value);
     }
 
     private static <T> boolean validateSetElement(ConfiguredSet<T> configuredSet, Object value) {
-        return validateCollectionElement(configuredSet.nestedType(), value);
+        return validateCollectionElementType(configuredSet.nestedType(), value) && validateCollectionElement(configuredSet, value);
     }
 
-    private static <T> boolean validateCollectionElement(Class<T> nestedType, Object value) {
+    @SuppressWarnings("unchecked")
+    private static <T> boolean validateCollectionElement(ConfiguredList<T> configuredList, Object value) {
+        final var mappedValue = (T) mapConfigValueFromNeoForge(configuredList.nestedType(), value);
+        return configuredList.validateElement(mappedValue).isSuccess();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> boolean validateCollectionElement(ConfiguredSet<T> configuredSet, Object value) {
+        final var mappedValue = (T) mapConfigValueFromNeoForge(configuredSet.nestedType(), value);
+        return configuredSet.validateElement(mappedValue).isSuccess();
+    }
+
+    private static <T> boolean validateCollectionElementType(Class<T> nestedType, Object value) {
         if (nestedType == Boolean.class) {
             return value instanceof Boolean || ("true".equals(value) || "false".equals(value));
         } else if (nestedType == Double.class) {
@@ -184,7 +215,7 @@ public class ForgeBalmConfig extends AbstractBalmConfig {
     }
 
     private static <T extends Enum<T>> ForgeConfigSpec.ConfigValue<T> defineEnum(ForgeConfigSpec.Builder spec, ConfiguredEnum<T> configuredEnum) {
-        return spec.defineEnum(configuredEnum.name(), configuredEnum.defaultValue(), EnumGetMethod.NAME_IGNORECASE);
+        return spec.defineEnum(configuredEnum.name(), configuredEnum.defaultValue(), EnumGetMethod.NAME_IGNORECASE, it -> validatePropertyValue(configuredEnum, it));
     }
 
     @Override

--- a/forge/src/main/java/net/blay09/mods/balm/forge/platform/config/internal/ForgeBalmConfig.java
+++ b/forge/src/main/java/net/blay09/mods/balm/forge/platform/config/internal/ForgeBalmConfig.java
@@ -51,11 +51,7 @@ public class ForgeBalmConfig extends AbstractBalmConfig {
             case ConfiguredInt configuredInt -> configuredInt.hasCustomValidator()
                     ? spec.define(configuredInt.name(), configuredInt.defaultValue(), it -> validatePropertyValue(configuredInt, it))
                     : spec.defineInRange(configuredInt.name(), configuredInt.defaultValue(), configuredInt.minValue().orElse(Integer.MIN_VALUE), configuredInt.maxValue().orElse(Integer.MAX_VALUE));
-            case ConfiguredList<?> configuredList -> configuredList.hasCustomCollectionValidator()
-                    ? spec.define(configuredList.name(),
-                    mapConfigCollectionToNeoForge(configuredList.defaultValue()),
-                    it -> validatePropertyValue(configuredList, it))
-                    : spec.defineListAllowEmpty(configuredList.name(),
+            case ConfiguredList<?> configuredList -> spec.defineListAllowEmpty(configuredList.name(),
                     mapConfigCollectionToNeoForge(configuredList.defaultValue()),
                     it -> validateListElement(configuredList, it));
             case ConfiguredLong configuredLong -> configuredLong.hasCustomValidator()
@@ -64,11 +60,7 @@ public class ForgeBalmConfig extends AbstractBalmConfig {
             case ConfiguredIdentifier configuredIdentifier -> configuredIdentifier.hasCustomValidator()
                     ? spec.define(configuredIdentifier.name(), configuredIdentifier.defaultValue().toString(), it -> validatePropertyValue(configuredIdentifier, it))
                     : spec.define(configuredIdentifier.name(), configuredIdentifier.defaultValue().toString());
-            case ConfiguredSet<?> configuredSet -> configuredSet.hasCustomCollectionValidator()
-                    ? spec.define(configuredSet.name(),
-                    mapConfigCollectionToNeoForge(configuredSet.defaultValue()),
-                    it -> validatePropertyValue(configuredSet, it))
-                    : spec.defineListAllowEmpty(configuredSet.name(),
+            case ConfiguredSet<?> configuredSet -> spec.defineListAllowEmpty(configuredSet.name(),
                     mapConfigCollectionToNeoForge(configuredSet.defaultValue()),
                     it -> validateSetElement(configuredSet, it));
             case ConfiguredString configuredString -> configuredString.hasCustomValidator()

--- a/neoforge/src/main/java/net/blay09/mods/balm/neoforge/platform/config/internal/NeoForgeBalmConfig.java
+++ b/neoforge/src/main/java/net/blay09/mods/balm/neoforge/platform/config/internal/NeoForgeBalmConfig.java
@@ -55,12 +55,7 @@ public class NeoForgeBalmConfig extends AbstractBalmConfig {
             case ConfiguredInt configuredInt -> configuredInt.hasCustomValidator()
                     ? spec.define(configuredInt.name(), configuredInt.defaultValue(), it -> validatePropertyValue(configuredInt, it))
                     : spec.defineInRange(configuredInt.name(), configuredInt.defaultValue(), configuredInt.minValue().orElse(Integer.MIN_VALUE), configuredInt.maxValue().orElse(Integer.MAX_VALUE));
-            case ConfiguredList<?> configuredList -> configuredList.hasCustomCollectionValidator()
-                    ? spec.defineListAllowEmpty(configuredList.name(),
-                    mapConfigCollectionToNeoForge(configuredList.defaultValue()),
-                    () -> newListElement(configuredList),
-                    it -> validatePropertyValue(configuredList, it))
-                    : spec.defineListAllowEmpty(configuredList.name(),
+            case ConfiguredList<?> configuredList -> spec.defineListAllowEmpty(configuredList.name(),
                     mapConfigCollectionToNeoForge(configuredList.defaultValue()),
                     () -> newListElement(configuredList),
                     it -> validateListElement(configuredList, it));
@@ -70,12 +65,7 @@ public class NeoForgeBalmConfig extends AbstractBalmConfig {
             case ConfiguredIdentifier configuredIdentifier -> configuredIdentifier.hasCustomValidator()
                     ? spec.define(configuredIdentifier.name(), configuredIdentifier.defaultValue().toString(), it -> validatePropertyValue(configuredIdentifier, it))
                     : spec.define(configuredIdentifier.name(), configuredIdentifier.defaultValue().toString());
-            case ConfiguredSet<?> configuredSet -> configuredSet.hasCustomCollectionValidator()
-                    ? spec.defineListAllowEmpty(configuredSet.name(),
-                    mapConfigCollectionToNeoForge(configuredSet.defaultValue()),
-                    () -> newSetElement(configuredSet),
-                    it -> validatePropertyValue(configuredSet, it))
-                    : spec.defineListAllowEmpty(configuredSet.name(),
+            case ConfiguredSet<?> configuredSet -> spec.defineListAllowEmpty(configuredSet.name(),
                     mapConfigCollectionToNeoForge(configuredSet.defaultValue()),
                     () -> newSetElement(configuredSet),
                     it -> validateSetElement(configuredSet, it));

--- a/neoforge/src/main/java/net/blay09/mods/balm/neoforge/platform/config/internal/NeoForgeBalmConfig.java
+++ b/neoforge/src/main/java/net/blay09/mods/balm/neoforge/platform/config/internal/NeoForgeBalmConfig.java
@@ -42,37 +42,54 @@ public class NeoForgeBalmConfig extends AbstractBalmConfig {
         spec.translation(ConfigLocalization.forProperty(property));
 
         return switch (property) {
-            case ConfiguredBoolean configuredBoolean ->
-                    spec.define(configuredBoolean.name(), configuredBoolean.defaultValue().booleanValue());
-            case ConfiguredDouble configuredDouble ->
-                    configuredDouble.minValue().isPresent() || configuredDouble.maxValue().isPresent()
-                            ? spec.defineInRange(configuredDouble.name(), configuredDouble.defaultValue(), configuredDouble.minValue().orElse(Double.NEGATIVE_INFINITY), configuredDouble.maxValue().orElse(Double.POSITIVE_INFINITY))
-                            : spec.define(configuredDouble.name(), configuredDouble.defaultValue());
+            case ConfiguredBoolean configuredBoolean -> configuredBoolean.hasCustomValidator()
+                    ? spec.define(configuredBoolean.name(), configuredBoolean.defaultValue(), it -> validatePropertyValue(configuredBoolean, it))
+                    : spec.define(configuredBoolean.name(), configuredBoolean.defaultValue().booleanValue());
+            case ConfiguredDouble configuredDouble -> configuredDouble.hasCustomValidator()
+                    ? spec.define(configuredDouble.name(), configuredDouble.defaultValue(), it -> validatePropertyValue(configuredDouble, it))
+                    : spec.defineInRange(configuredDouble.name(), configuredDouble.defaultValue(), configuredDouble.minValue().orElse(Double.NEGATIVE_INFINITY), configuredDouble.maxValue().orElse(Double.POSITIVE_INFINITY));
             case ConfiguredEnum<?> configuredEnum -> defineEnum(spec, configuredEnum);
-            case ConfiguredFloat configuredFloat ->
-                    configuredFloat.minValue().isPresent() || configuredFloat.maxValue().isPresent()
-                            ? spec.defineInRange(configuredFloat.name(), configuredFloat.defaultValue().doubleValue(), (double) configuredFloat.minValue().orElse(Float.NEGATIVE_INFINITY), (double) configuredFloat.maxValue().orElse(Float.POSITIVE_INFINITY))
-                            : spec.define(configuredFloat.name(), configuredFloat.defaultValue().doubleValue());
-            case ConfiguredInt configuredInt -> configuredInt.minValue().isPresent() || configuredInt.maxValue().isPresent()
-                    ? spec.defineInRange(configuredInt.name(), configuredInt.defaultValue(), configuredInt.minValue().orElse(Integer.MIN_VALUE), configuredInt.maxValue().orElse(Integer.MAX_VALUE))
-                    : spec.define(configuredInt.name(), configuredInt.defaultValue());
-            case ConfiguredList<?> configuredList -> spec.defineListAllowEmpty(configuredList.name(),
+            case ConfiguredFloat configuredFloat -> configuredFloat.hasCustomValidator()
+                    ? spec.define(configuredFloat.name(), configuredFloat.defaultValue().doubleValue(), it -> validatePropertyValue(configuredFloat, it))
+                    : spec.defineInRange(configuredFloat.name(), configuredFloat.defaultValue().doubleValue(), (double) configuredFloat.minValue().orElse(Float.NEGATIVE_INFINITY), (double) configuredFloat.maxValue().orElse(Float.POSITIVE_INFINITY));
+            case ConfiguredInt configuredInt -> configuredInt.hasCustomValidator()
+                    ? spec.define(configuredInt.name(), configuredInt.defaultValue(), it -> validatePropertyValue(configuredInt, it))
+                    : spec.defineInRange(configuredInt.name(), configuredInt.defaultValue(), configuredInt.minValue().orElse(Integer.MIN_VALUE), configuredInt.maxValue().orElse(Integer.MAX_VALUE));
+            case ConfiguredList<?> configuredList -> configuredList.hasCustomCollectionValidator()
+                    ? spec.defineListAllowEmpty(configuredList.name(),
                     mapConfigCollectionToNeoForge(configuredList.defaultValue()),
                     () -> newListElement(configuredList),
-                    (it) -> validateListElement(configuredList, it));
-            case ConfiguredLong configuredLong -> configuredLong.minValue().isPresent() || configuredLong.maxValue().isPresent()
-                    ? spec.defineInRange(configuredLong.name(), configuredLong.defaultValue(), configuredLong.minValue().orElse(Long.MIN_VALUE), configuredLong.maxValue().orElse(Long.MAX_VALUE))
-                    : spec.define(configuredLong.name(), configuredLong.defaultValue());
-            case ConfiguredIdentifier configuredIdentifier ->
-                    spec.define(configuredIdentifier.name(), configuredIdentifier.defaultValue().toString());
-            case ConfiguredSet<?> configuredSet -> spec.defineListAllowEmpty(configuredSet.name(),
+                    it -> validatePropertyValue(configuredList, it))
+                    : spec.defineListAllowEmpty(configuredList.name(),
+                    mapConfigCollectionToNeoForge(configuredList.defaultValue()),
+                    () -> newListElement(configuredList),
+                    it -> validateListElement(configuredList, it));
+            case ConfiguredLong configuredLong -> configuredLong.hasCustomValidator()
+                    ? spec.define(configuredLong.name(), configuredLong.defaultValue(), it -> validatePropertyValue(configuredLong, it))
+                    : spec.defineInRange(configuredLong.name(), configuredLong.defaultValue(), configuredLong.minValue().orElse(Long.MIN_VALUE), configuredLong.maxValue().orElse(Long.MAX_VALUE));
+            case ConfiguredIdentifier configuredIdentifier -> configuredIdentifier.hasCustomValidator()
+                    ? spec.define(configuredIdentifier.name(), configuredIdentifier.defaultValue().toString(), it -> validatePropertyValue(configuredIdentifier, it))
+                    : spec.define(configuredIdentifier.name(), configuredIdentifier.defaultValue().toString());
+            case ConfiguredSet<?> configuredSet -> configuredSet.hasCustomCollectionValidator()
+                    ? spec.defineListAllowEmpty(configuredSet.name(),
                     mapConfigCollectionToNeoForge(configuredSet.defaultValue()),
                     () -> newSetElement(configuredSet),
-                    (it) -> validateSetElement(configuredSet, it));
-            case ConfiguredString configuredString ->
-                    spec.define(configuredString.name(), configuredString.defaultValue());
+                    it -> validatePropertyValue(configuredSet, it))
+                    : spec.defineListAllowEmpty(configuredSet.name(),
+                    mapConfigCollectionToNeoForge(configuredSet.defaultValue()),
+                    () -> newSetElement(configuredSet),
+                    it -> validateSetElement(configuredSet, it));
+            case ConfiguredString configuredString -> configuredString.hasCustomValidator()
+                    ? spec.define(configuredString.name(), configuredString.defaultValue(), it -> validatePropertyValue(configuredString, it))
+                    : spec.define(configuredString.name(), configuredString.defaultValue());
             default -> throw new IllegalStateException("Unexpected value: " + property);
         };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> boolean validatePropertyValue(ConfiguredProperty<T> property, Object value) {
+        final var mappedValue = (T) mapConfigValueFromNeoForge(property, value);
+        return property.validateValue(mappedValue).isSuccess();
     }
 
     public static List<?> mapConfigCollectionToNeoForge(Collection<?> values) {
@@ -151,14 +168,26 @@ public class NeoForgeBalmConfig extends AbstractBalmConfig {
     }
 
     private static <T> boolean validateListElement(ConfiguredList<T> configuredList, Object value) {
-        return validateCollectionElement(configuredList.nestedType(), value);
+        return validateCollectionElementType(configuredList.nestedType(), value) && validateCollectionElement(configuredList, value);
     }
 
     private static <T> boolean validateSetElement(ConfiguredSet<T> configuredSet, Object value) {
-        return validateCollectionElement(configuredSet.nestedType(), value);
+        return validateCollectionElementType(configuredSet.nestedType(), value) && validateCollectionElement(configuredSet, value);
     }
 
-    private static <T> boolean validateCollectionElement(Class<T> nestedType, Object value) {
+    @SuppressWarnings("unchecked")
+    private static <T> boolean validateCollectionElement(ConfiguredList<T> configuredList, Object value) {
+        final var mappedValue = (T) mapConfigValueFromNeoForge(configuredList.nestedType(), value);
+        return configuredList.validateElement(mappedValue).isSuccess();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> boolean validateCollectionElement(ConfiguredSet<T> configuredSet, Object value) {
+        final var mappedValue = (T) mapConfigValueFromNeoForge(configuredSet.nestedType(), value);
+        return configuredSet.validateElement(mappedValue).isSuccess();
+    }
+
+    private static <T> boolean validateCollectionElementType(Class<T> nestedType, Object value) {
         if (nestedType == Boolean.class) {
             return value instanceof Boolean || ("true".equals(value) || "false".equals(value));
         } else if (nestedType == Double.class) {
@@ -225,7 +254,7 @@ public class NeoForgeBalmConfig extends AbstractBalmConfig {
     }
 
     private static <T extends Enum<T>> ModConfigSpec.ConfigValue<T> defineEnum(ModConfigSpec.Builder spec, ConfiguredEnum<T> configuredEnum) {
-        return spec.defineEnum(configuredEnum.name(), configuredEnum.defaultValue(), EnumGetMethod.NAME_IGNORECASE);
+        return spec.defineEnum(configuredEnum.name(), configuredEnum.defaultValue(), EnumGetMethod.NAME_IGNORECASE, it -> validatePropertyValue(configuredEnum, it));
     }
 
     @Override


### PR DESCRIPTION
```java
@Comment("Example string config value.")
@ValidateWith(WelcomeMessageValidator.class)
public String welcomeMessage = "Hello from Balm!";
```

```java
public static class WelcomeMessageValidator implements ConfigValidator<String> {
    @Override
    public DataResult<String> validate(String value) {
        if (value.isBlank()) {
            return DataResult.error(() -> "Welcome message must not be blank");
        }

        return DataResult.success(value);
    }
}
```

## To Do

- [x] Hook it up to Forge/NeoForge config system too, where possible
- [x] Hook it up to other config screens as well, where possible